### PR TITLE
Splitting idrepo and cts snapshots

### DIFF
--- a/charts/identity-platform/templates/ds-cts-snapshot-cronjob.yaml
+++ b/charts/identity-platform/templates/ds-cts-snapshot-cronjob.yaml
@@ -1,19 +1,18 @@
-{{- if .Values.ds_snapshot.enabled }}
----
+{{- if .Values.ds_cts.snapshot.enabled }}
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ .Values.ds_snapshot.name }}
+  name: {{ .Values.ds_cts.snapshot.name }}
 spec:
-  schedule: {{ .Values.ds_snapshot.schedule | quote }}
+  schedule: {{ .Values.ds_cts.snapshot.schedule | quote }}
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:
       template:
         metadata:
-          name: {{ .Values.ds_snapshot.name }}
+          name: {{ .Values.ds_cts.snapshot.name }}
           labels:
-            app: {{ .Values.ds_snapshot.name }}-job
+            app: {{ .Values.ds_cts.snapshot.name }}-job
         spec:
           {{- if .Values.ds_snapshot.image.imagePullSecrets }}
           imagePullSecrets:
@@ -22,17 +21,17 @@ spec:
           imagePullSecrets:
             {{- toYaml .Values.imagePullSecrets | nindent 14 }}
           {{- end }}
-          serviceAccountName: {{ .Values.ds_snapshot.serviceAccountName }}
+          serviceAccountName: {{ .Values.ds_cts.snapshot.serviceAccountName }}
           securityContext:
-            {{- toYaml .Values.ds_snapshot.podSecurityContext | nindent 14 }}
+            {{- toYaml .Values.ds_cts.snapshot.podSecurityContext | nindent 14 }}
           containers:
-          - name: {{ .Values.ds_snapshot.name }}
+          - name: {{ .Values.ds_cts.snapshot.name }}
             image: {{ .Values.ds_snapshot.image.repository }}:{{ .Values.ds_snapshot.image.tag }}
             imagePullPolicy: {{ .Values.ds_snapshot.image.pullPolicy }}
             command:
             - /bin/bash
             - -c
-            - /scripts/snapshot.sh {{ .Values.ds_snapshot.name }} {{ .Values.ds_snapshot.pvcName }} {{ .Values.ds_snapshot.class }}
+            - /scripts/snapshot.sh {{ .Values.ds_cts.snapshot.name }} {{ .Values.ds_cts.snapshot.pvcName }} {{ .Values.ds_cts.snapshot.class }}
             env:
             - name: NAMESPACE
               valueFrom:
@@ -43,14 +42,14 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: PURGE_DELAY
-              value: {{ .Values.ds_snapshot.purgeDelay | quote }}
+              value: {{ .Values.ds_cts.snapshot.purgeDelay | quote }}
             volumeMounts:
-            - name: {{ .Values.ds_snapshot.name }}-script
+            - name: {{ .Values.ds_cts.snapshot.name }}-script
               mountPath: /scripts
           volumes:
-          - name: {{ .Values.ds_snapshot.name }}-script
+          - name: {{ .Values.ds_cts.snapshot.name }}-script
             configMap:
-              name: {{ .Values.ds_snapshot.name }}-script
+              name: {{ .Values.ds_cts.snapshot.name }}-script
               defaultMode: 0555
           restartPolicy: Never
 {{- end }}

--- a/charts/identity-platform/templates/ds-idrepo-snapshot-cronjob.yaml
+++ b/charts/identity-platform/templates/ds-idrepo-snapshot-cronjob.yaml
@@ -1,0 +1,55 @@
+{{- if .Values.ds_idrepo.snapshot.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ .Values.ds_idrepo.snapshot.name }}
+spec:
+  schedule: {{ .Values.ds_idrepo.snapshot.schedule | quote }}
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          name: {{ .Values.ds_idrepo.snapshot.name }}
+          labels:
+            app: {{ .Values.ds_idrepo.snapshot.name }}-job
+        spec:
+          {{- if .Values.ds_snapshot.image.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml .Values.ds_snapshot.image.imagePullSecrets | nindent 14 }}
+          {{- else if .Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml .Values.imagePullSecrets | nindent 14 }}
+          {{- end }}
+          serviceAccountName: {{ .Values.ds_idrepo.snapshot.serviceAccountName }}
+          securityContext:
+            {{- toYaml .Values.ds_idrepo.snapshot.podSecurityContext | nindent 14 }}
+          containers:
+          - name: {{ .Values.ds_idrepo.snapshot.name }}
+            image: {{ .Values.ds_snapshot.image.repository }}:{{ .Values.ds_snapshot.image.tag }}
+            imagePullPolicy: {{ .Values.ds_snapshot.image.pullPolicy }}
+            command:
+            - /bin/bash
+            - -c
+            - /scripts/snapshot.sh {{ .Values.ds_idrepo.snapshot.name }} {{ .Values.ds_idrepo.snapshot.pvcName }} {{ .Values.ds_idrepo.snapshot.class }}
+            env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: PURGE_DELAY
+              value: {{ .Values.ds_idrepo.snapshot.purgeDelay | quote }}
+            volumeMounts:
+            - name: {{ .Values.ds_idrepo.snapshot.name }}-script
+              mountPath: /scripts
+          volumes:
+          - name: {{ .Values.ds_idrepo.snapshot.name }}-script
+            configMap:
+              name: {{ .Values.ds_idrepo.snapshot.name }}-script
+              defaultMode: 0555
+          restartPolicy: Never
+{{- end }}

--- a/charts/identity-platform/templates/ds-snapshot-configmap.yaml
+++ b/charts/identity-platform/templates/ds-snapshot-configmap.yaml
@@ -1,5 +1,4 @@
-{{- if and .Values.ds_snapshot.enabled .Values.ds_snapshot.configmapCreate }}
----
+{{- if and .Values.ds_snapshot.configmapCreate (or .Values.ds_idrepo.snapshot.enabled .Values.ds_cts.snapshot.enabled) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/identity-platform/templates/ds-snapshot-rbac.yaml
+++ b/charts/identity-platform/templates/ds-snapshot-rbac.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.ds_snapshot.enabled .Values.ds_snapshot.rbacCreate }}
+{{- if and .Values.ds_snapshot.rbacCreate (or .Values.ds_idrepo.snapshot.enabled .Values.ds_cts.snapshot.enabled) }}
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/charts/identity-platform/values.yaml
+++ b/charts/identity-platform/values.yaml
@@ -635,6 +635,18 @@ ig:
     type: ClusterIP
     port: 80
 
+# Common values for doing ds snapshots
+ds_snapshot:
+  configmapCreate: true
+  rbacCreate: true
+  serviceAccountName: ds-snapshot
+
+  image:
+    repository: bitnami/kubectl
+    tag: latest
+    pullPolicy: IfNotPresent
+    imagePullSecrets: []
+
 ds_idrepo:
   enabled: true
   replicaCount: 1
@@ -691,6 +703,19 @@ ds_idrepo:
   service:
     type: ClusterIP
     port: 8080
+
+  snapshot:
+    enabled: false
+    class: ds-snapshot-class
+    name: ds-idrepo-snapshot
+    podSecurityContext: {}
+    pvcName: data-ds-idrepo-0
+
+    # Daily snaphot at midnight
+    schedule: "0 0 * * *"
+
+    # Purge snaps older than 3 days
+    purgeDelay: "-3 day"
 
 ds_cts:
   enabled: true
@@ -749,25 +774,15 @@ ds_cts:
     type: ClusterIP
     port: 8080
 
-# Setup a cronjob to take regular volume snapshots of ds-idrepo
-ds_snapshot:
-  enabled: false
-  class: ds-snapshot-class
-  configmapCreate: true
-  name: ds-snapshot
-  podSecurityContext: {}
-  pvcName: data-ds-idrepo-0
-  rbacCreate: true
-  serviceAccountName: ds-snapshot
+  snapshot:
+    enabled: false
+    class: ds-snapshot-class
+    name: ds-cts-snapshot
+    podSecurityContext: {}
+    pvcName: data-ds-cts-0
 
-  # Daily snaphot at midnight
-  schedule: "0 0 * * *"
+    # Daily snaphot at midnight
+    schedule: "0 0 * * *"
 
-  # Purge snaps older than 3 days
-  purgeDelay: "-3 day"
-
-  image:
-    repository: bitnami/kubectl
-    tag: latest
-    pullPolicy: IfNotPresent
-    imagePullSecrets: []
+    # Purge snaps older than 3 days
+    purgeDelay: "-3 day"


### PR DESCRIPTION
Keeping ds_snapshot values for shared settings
Keeping configmap, rbac, and image settings as shared settings

ref: FORGEOPS-4596