### PR TITLE
allow to use custom terraform installation path

### DIFF
--- a/terraform/tf-apply
+++ b/terraform/tf-apply
@@ -1,7 +1,13 @@
 #!/bin/bash
 
 terraform_dir=$(dirname $0)
-terraform_bin=$(type -p terraform)
+
+if [ -z "${TERRAFORM_BIN}" ] ; then
+    terraform_bin=$(type -p terraform)
+else
+    terraform_bin=${TERRAFORM_BIN}
+fi
+
 if [ -z "$terraform_bin" ]; then
     echo "Could not find terraform binary in PATH.  Exiting."
     exit 1

--- a/terraform/tf-destroy
+++ b/terraform/tf-destroy
@@ -1,7 +1,13 @@
 #!/bin/bash
 
 terraform_dir=$(dirname $0)
-terraform_bin=$(type -p terraform)
+
+if [ -z "${TERRAFORM_BIN}" ] ; then
+    terraform_bin=$(type -p terraform)
+else
+    terraform_bin=${TERRAFORM_BIN}
+fi
+
 if [ -z "$terraform_bin" ]; then
     echo "Could not find terraform binary in PATH.  Exiting."
     exit 1


### PR DESCRIPTION
if TERRAFORM_BIN shell environment variable is defined, then tf-apply and tf-destroy should use custom terraform installation, else use default one
